### PR TITLE
Added bower as a package manager option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Include the stylesheet:
   ```js
   require('vue-animate/dist/vue-animate.min.css')
   ```
+
+####bower
+  ```shell
+  bower install --save vue-animate
+  ```
+
 ####Less
   ```less
   @import "<PATH_TO_SOURCE>/src/vue-animate.less";

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "vue-animate",
+  "version": "0.0.5",
+  "description": "LESS cross-browser animation library, for use with Vue.js. Ported from Animate.css.",
+  "authors": [
+    "Hayden Bickerton <haydenbbickerton@gmail.com>"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/haydenbbickerton/vue-animate.git"
+  },
+  "main": "dist/vue-animate.css",
+  "bugs": {
+    "url": "https://github.com/haydenbbickerton/vue-animate/issues"
+  },
+  "keywords": [
+    "less",
+    "animate",
+    "animate.css",
+    "vue",
+    "vue.js",
+    "transition",
+    "vue-animate",
+    "css"
+  ],
+  "ignore": [
+    "src"
+  ]
+}


### PR DESCRIPTION
Hello Hayden Bickerton,

i would love it, if you accept my pull request. This would just add the possibility to use bower as package manager besides npm. We already tested your plugin and really liked it. You have just to register your package in the bower repo with following command:

bower register vue-animate git://github.com/haydenbbickerton/vue-animate.git

and tag your future commits or use github web tool for tagging a release. I recommend to read following article regarding bower:

http://bob.yexley.net/creating-and-maintaining-your-own-bower-package/

Greetings from Germany,
Benjamin Stelljes

---

Tagging commits:
# commit your changes

git commit -am "Made some awesome new changes, now its even awesomer"
# tag the commit

git tag -a v0.0.2 -m "Release version 0.0.2"
# push to GitHub

git push origin master --tags  
